### PR TITLE
Simplify artefact names

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,4 +12,5 @@ builds:
 archive:
   name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}_{{.Arch}}"
   format: tar.gz
-
+  replacements:
+    amd64: x86_64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,4 @@ builds:
 archive:
   name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}_{{.Arch}}"
   format: tar.gz
-  replacements:
-    amd64: 64-bit
-    darwin: macOS
+


### PR DESCRIPTION
See #50 . I've just removed the replacement section of the `.goreleaser.yml` file